### PR TITLE
is_ready returns non-existent self.credentials

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -83,7 +83,7 @@ class OpenStackIntegrationRequires(Endpoint):
         """
         Whether or not the request for this instance has been completed.
         """
-        return bool(self.credentials)
+        return bool(self._received)
 
     @property
     def auth_url(self):


### PR DESCRIPTION
When openstack-integrator is related to kube-master/kube-worker, it causes: hook failed: "openstack-relation-joined"
Looking at the code, found the following error:

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-master-7/.venv/lib/python3.5/site-packages/charms/reactive/__init__.py", line 72, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-master-7/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 382, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-master-7/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 358, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-master-7/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 180, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-master-7/charm/hooks/relations/openstack-integration/requires.py", line 74, in check_ready
    toggle_flag(self.expand_name('ready'), self.is_ready)
  File "/var/lib/juju/agents/unit-kubernetes-master-7/charm/hooks/relations/openstack-integration/requires.py", line 86, in is_ready
    return bool(self.credentials)
AttributeError: 'OpenStackIntegrationRequires' object has no attribute 'credentials'
```

However, according with line: https://github.com/juju-solutions/charm-openstack-integrator/blob/ee8172a3d903cbfaf2ca22f60bf84fa29664076a/reactive/openstack.py#L39
Data is set on the relation using method set_credentials, which is defined on:
https://github.com/phvalguima/interface-openstack-integration/blob/master/provides.py#L88
And uses `relation.to_publish.update` to send data to kube-masters/workers.
Therefore, data should be recovered (or checked as existent) using `self._received` instead of self.credentials.
More details of the error on: https://pastebin.ubuntu.com/p/gctV3kcQNQ/