### PR TITLE
add endpoint CA certificate handling

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -91,7 +91,8 @@ class IntegrationRequest:
                         password,
                         user_domain_name,
                         project_domain_name,
-                        project_name):
+                        project_name,
+                        endpoint_tls_ca):
         """
         Set the credentials for this request.
         """
@@ -102,6 +103,7 @@ class IntegrationRequest:
             'user_domain_name': user_domain_name,
             'project_domain_name': project_domain_name,
             'project_name': project_name,
+            'endpoint_tls_ca': endpoint_tls_ca,
         })
 
     @property

--- a/requires.py
+++ b/requires.py
@@ -119,3 +119,7 @@ class OpenStackIntegrationRequires(Endpoint):
     @property
     def project_name(self):
         return self._received['project_name']
+
+    @property
+    def endpoint_tls_ca(self):
+        return self._received['endpoint_tls_ca']


### PR DESCRIPTION
OpenStack clouds often have TLS termination with certs signed by
non-public CAs which cannot be verified with a standard set of CA certs
shipped in the core snap used by other snaps.

There is a way to provide a path to a ca-file in cloud.conf for k8s
in-tree OpenStack provider code which relies on gophercloud to use
that cert when creating an HTTP client for o7k endpoint communication.

The content of the CA certificate has to come from the integrator charm
which is not a subordinate, therefore, it must expose that cert over
a relation with other charms consuming data required to render
cloud.conf.