### PR TITLE
Add internal_lb to interface

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -119,7 +119,8 @@ class IntegrationRequest:
                          floating_network_id,
                          lb_method,
                          manage_security_groups,
-                         has_octavia=None):
+                         has_octavia=None,
+                         internal_lb=False):
         """
         Set the load-balancer-as-a-service config for this request.
         """
@@ -127,6 +128,7 @@ class IntegrationRequest:
             'subnet_id': subnet_id,
             'floating_network_id': floating_network_id,
             'lb_method': lb_method,
+            'internal_lb': internal_lb,
             'manage_security_groups': manage_security_groups,
             'has_octavia': has_octavia,
         })

--- a/requires.py
+++ b/requires.py
@@ -118,6 +118,7 @@ class OpenStackIntegrationRequires(Endpoint):
             self.subnet_id,
             self.floating_network_id,
             self.lb_method,
+            self.internal_lb,
             self.manage_security_groups,
         ])
 
@@ -205,6 +206,14 @@ class OpenStackIntegrationRequires(Endpoint):
         Optional load-balancer method, or None.
         """
         return self._received['lb_method']
+
+    @property
+    def internal_lb(self) -> bool:
+        """
+        If should force internal loadbalancer use.
+        Defaults to false.
+        """
+        return bool(self._received.get('internal_lb', False))
 
     @property
     def manage_security_groups(self):


### PR DESCRIPTION
This is so internal-lb con be configured in charm-openstack-integrator,
and the value passed to charm-kubernetes-control-plane
via this interface
to be used in the config for cloud-provider-openstack.

Note that the code that reads this internal_lb value
is actually in layer-kubernetes-common (python library).
charm-kubernetes-control-plane calls functions from that library.

Related PRs:
- https://github.com/juju-solutions/charm-openstack-integrator/pull/60
- https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/26

Launchpad bug: [#1877692](https://bugs.launchpad.net/charm-openstack-integrator/+bug/1877692)