### PR TITLE
Add lb_enabled to the relation

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -120,6 +120,7 @@ class IntegrationRequest:
                          lb_method,
                          manage_security_groups,
                          has_octavia=None,
+                         lb_enabled=None,
                          internal_lb=False):
         """
         Set the load-balancer-as-a-service config for this request.
@@ -131,6 +132,7 @@ class IntegrationRequest:
             'internal_lb': internal_lb,
             'manage_security_groups': manage_security_groups,
             'has_octavia': has_octavia,
+            'lb_enabled': lb_enabled,
         })
 
     def set_block_storage_config(self,

--- a/requires.py
+++ b/requires.py
@@ -269,4 +269,5 @@ class OpenStackIntegrationRequires(Endpoint):
         Whether or not LoadBalancer service integration should be enabled in
         openstack-cloud-controller-manager.
         """
-        return self._received['lb_enabled']
+        # be careful to ensure a None value is returned as True, for backward compatibility
+        return self._received['lb_enabled'] is not False

--- a/requires.py
+++ b/requires.py
@@ -120,6 +120,7 @@ class OpenStackIntegrationRequires(Endpoint):
             self.lb_method,
             self.internal_lb,
             self.manage_security_groups,
+            self.lb_enabled,
         ])
 
     @property
@@ -261,3 +262,11 @@ class OpenStackIntegrationRequires(Endpoint):
         some reason (typically due to connecting to an older integrator charm).
         """
         return self._received['has_octavia']
+
+    @property
+    def lb_enabled(self):
+        """
+        Whether or not LoadBalancer service integration should be enabled in
+        openstack-cloud-controller-manager.
+        """
+        return self._received['lb_enabled']


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/bugs/1995746 and https://bugs.launchpad.net/bugs/1990494

The openstack-integrator charm will gain a new config option, `lb_enabled`, to control whether LoadBalancer support should be enabled in openstack-cloud-controller-manager (OCCM). The OCCM config is rendered by kubernetes-control-plane, so, `lb_enabled` needs to be sent over the relation.

Thanks to @nikolayvinogradov for the initial work on this!