### PR TITLE
ignore the ops directory when building the reactive layer

### DIFF
--- a/interface.yaml
+++ b/interface.yaml
@@ -2,3 +2,5 @@ name: openstack-integration
 summary: Interface for connecting to the OpenStack integrator charm.
 version: 1
 maintainer: Cory Johns <cory.johns@canonical.com>
+ignore:
+- ops


### PR DESCRIPTION
the reactive interface layer doesn't need any of the `ops` library path from this repo